### PR TITLE
agent-sdk: Add cjs and esm builds

### DIFF
--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -20,15 +20,16 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/mjs/index.js",
+  "types": "dist/esm/index.d.ts",
   "files": [
-    "dist"
+    "dist/**/*"
   ],
   "scripts": {
-    "build": "tsc"
+    "build": "rm -fr dist/* && bun build:esm && bun build:cjs",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json"
   },
   "dependencies": {
     "viem": "^2.21.53",

--- a/packages/agent-sdk/tsconfig.cjs.json
+++ b/packages/agent-sdk/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+      "module": "commonjs",
+      "outDir": "dist/cjs",
+  }
+}

--- a/packages/agent-sdk/tsconfig.cjs.json
+++ b/packages/agent-sdk/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-      "module": "commonjs",
-      "outDir": "dist/cjs",
+    "module": "commonjs",
+    "outDir": "dist/cjs"
   }
 }

--- a/packages/agent-sdk/tsconfig.esm.json
+++ b/packages/agent-sdk/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+      "target": "ESNext",  
+      "module": "ESNext",
+      "outDir": "dist/esm",
+  }
+}

--- a/packages/agent-sdk/tsconfig.esm.json
+++ b/packages/agent-sdk/tsconfig.esm.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-      "target": "ESNext",  
-      "module": "ESNext",
-      "outDir": "dist/esm",
+    "target": "ESNext",
+    "module": "ESNext",
+    "outDir": "dist/esm"
   }
 }

--- a/packages/agent-sdk/tsconfig.json
+++ b/packages/agent-sdk/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",  
+    "target": "ES2020",
     "moduleDetection": "force",
 
     // Bundler mode

--- a/packages/agent-sdk/tsconfig.json
+++ b/packages/agent-sdk/tsconfig.json
@@ -1,16 +1,12 @@
 {
   "compilerOptions": {
-    // Enable latest features
-    "lib": ["ESNext", "DOM"],
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "ES2020",  
     "moduleDetection": "force",
 
     // Bundler mode
-    "moduleResolution": "bundler",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "verbatimModuleSyntax": true,
     // "allowImportingTsExtensions": true,
     // "noEmit": true,
 


### PR DESCRIPTION
We have been struggling to deploy the uniswap agent to vercel and it seems its because there was only an esm build of this package.