### PR TITLE
[Bug] Use toFixed

### DIFF
--- a/packages/agent-sdk/src/evm/safe.ts
+++ b/packages/agent-sdk/src/evm/safe.ts
@@ -128,7 +128,7 @@ export async function flatSafeBalances(
 }
 
 // TODO(bh2smith): Move this into Zerion SDK
-function zerionToTokenBalance(userToken: UserToken): TokenBalance {
+export function zerionToTokenBalance(userToken: UserToken): TokenBalance {
   const { meta, balances } = userToken;
   return {
     tokenAddress: meta.contractAddress || null,
@@ -138,7 +138,7 @@ function zerionToTokenBalance(userToken: UserToken): TokenBalance {
       decimals: meta.decimals,
       logoUri: meta.tokenIcon || "",
     },
-    balance: parseUnits(balances.balance.toString(), meta.decimals).toString(), // Convert number to string
+    balance: parseUnits(balances.balance.toFixed(), meta.decimals).toString(), // Convert number to string
     fiatBalance: balances.usdBalance.toFixed(2),
     fiatConversion: (balances.price || 0).toFixed(2),
   };

--- a/packages/agent-sdk/tests/evm/safe.spec.ts
+++ b/packages/agent-sdk/tests/evm/safe.spec.ts
@@ -4,7 +4,6 @@ import {
   flatSafeBalances,
   zerionToTokenBalance,
 } from "../../src";
-import { UserToken } from "zerion-sdk";
 describe("getSafeBalances", () => {
   const originalWarn = console.warn;
 
@@ -22,23 +21,35 @@ describe("getSafeBalances", () => {
     await expect(getSafeBalances(999, zeroAddress)).resolves.toEqual([]);
   });
 
-  it("should throw error for unsupported chain ID", async () => {
-    const x: UserToken = {
-      chain: {
-        chainName: "",
-      },
-      balances: {
-        balance: 2.22047152096e-16,
-        usdBalance: 0,
-      },
-      meta: {
+  it("should throw error for unsupported chain ID", () => {
+    expect(
+      zerionToTokenBalance({
+        chain: {
+          chainName: "",
+        },
+        balances: {
+          balance: 2.22047152096e-16,
+          usdBalance: 0,
+        },
+        meta: {
+          name: "",
+          symbol: "",
+          decimals: 0,
+          isSpam: false,
+        },
+      }),
+    ).toEqual({
+      balance: "0",
+      fiatBalance: "0.00",
+      fiatConversion: "0.00",
+      token: {
+        decimals: 0,
+        logoUri: "",
         name: "",
         symbol: "",
-        decimals: 0,
-        isSpam: false,
       },
-    };
-    await expect(zerionToTokenBalance(x)).resolves.toEqual([]);
+      tokenAddress: null,
+    });
   });
 
   it.skip("should fetch balances for Arbitrum", async () => {

--- a/packages/agent-sdk/tests/evm/safe.spec.ts
+++ b/packages/agent-sdk/tests/evm/safe.spec.ts
@@ -1,5 +1,10 @@
 import { zeroAddress } from "viem";
-import { getSafeBalances, flatSafeBalances } from "../../src";
+import {
+  getSafeBalances,
+  flatSafeBalances,
+  zerionToTokenBalance,
+} from "../../src";
+import { UserToken } from "zerion-sdk";
 describe("getSafeBalances", () => {
   const originalWarn = console.warn;
 
@@ -15,6 +20,25 @@ describe("getSafeBalances", () => {
 
   it("should throw error for unsupported chain ID", async () => {
     await expect(getSafeBalances(999, zeroAddress)).resolves.toEqual([]);
+  });
+
+  it("should throw error for unsupported chain ID", async () => {
+    const x: UserToken = {
+      chain: {
+        chainName: "",
+      },
+      balances: {
+        balance: 2.22047152096e-16,
+        usdBalance: 0,
+      },
+      meta: {
+        name: "",
+        symbol: "",
+        decimals: 0,
+        isSpam: false,
+      },
+    };
+    await expect(zerionToTokenBalance(x)).resolves.toEqual([]);
   });
 
   it.skip("should fetch balances for Arbitrum", async () => {


### PR DESCRIPTION
We have been getting a parse error on number types

```
InvalidDecimalNumberError: Number `2.22047152096e-16` is not a valid decimal number.

Version: viem@2.21.52
    details: undefined,
   docsPath: undefined,
 metaMessages: undefined,
 shortMessage: "Number `2.22047152096e-16` is not a valid decimal number.",
    version: "2.21.52",
```

this resolves it in the simplest, quickest way.