### PR TITLE
Fix Native Asset Token Data Fetching

### DIFF
--- a/packages/agent-sdk/src/evm/erc20.ts
+++ b/packages/agent-sdk/src/evm/erc20.ts
@@ -61,7 +61,7 @@ export async function getTokenInfo(
   chainId: number,
   address: Address,
 ): Promise<TokenInfo> {
-  if (address === NATIVE_ASSET) {
+  if (address.toLowerCase() === NATIVE_ASSET.toLowerCase()) {
     return {
       address: NATIVE_ASSET,
       decimals: 18,

--- a/packages/agent-sdk/src/evm/erc20.ts
+++ b/packages/agent-sdk/src/evm/erc20.ts
@@ -3,6 +3,7 @@ import { encodeFunctionData, type Address } from "viem";
 import { getClient, type MetaTransaction } from "near-safe";
 import type { TokenInfo } from "./types";
 
+const NATIVE_ASSET = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const MAX_APPROVAL = BigInt(
   "115792089237316195423570985008687907853269984665640564039457584007913129639935",
 );
@@ -60,6 +61,15 @@ export async function getTokenInfo(
   chainId: number,
   address: Address,
 ): Promise<TokenInfo> {
+  if (address === NATIVE_ASSET) {
+    return {
+      address: NATIVE_ASSET,
+      decimals: 18,
+      // Not all Native Assets are ETH, but enough are.
+      symbol: "ETH",
+    };
+  }
+
   const [decimals, symbol] = await Promise.all([
     getTokenDecimals(chainId, address),
     getTokenSymbol(chainId, address),

--- a/packages/agent-sdk/tests/evm/token.spec.ts
+++ b/packages/agent-sdk/tests/evm/token.spec.ts
@@ -13,6 +13,19 @@ describe("getTokenDetails", () => {
     expect(tokenDetails).toBeDefined();
   });
 
+  it("should return the token details for native asset", async () => {
+    const tokenDetails = await getTokenDetails(
+      8453,
+      "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    );
+
+    expect(tokenDetails).toStrictEqual({
+      address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      decimals: 18,
+      symbol: "ETH",
+    });
+  });
+
   it("should return the token details for a given symbol", async () => {
     const tokenDetails = await getTokenDetails(43114, "UNI");
     expect(tokenDetails).toBeUndefined();


### PR DESCRIPTION
Previously we would get the following viem error when attempting to get native asset token data:

```
Error fetching token decimals: ContractFunctionExecutionError: The contract function \"decimals\" returned no data (\"0x\").

This could be due to any of the following:
  - The contract does not have the function \"decimals\",
  - The parameters passed to the contract function may be invalid, or
  - The address is not a contract.

Contract Call:
  address:   0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
  function:  decimals()

Docs: https://viem.sh/docs/contract/readContract
Version: viem@2.22.11
```