### PR TITLE
Add Reusable EVM Schemas

### DIFF
--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -3,3 +3,4 @@ export * from "./evm";
 export * from "./request";
 export * from "./error";
 export * from "./misc";
+export * from "./openai";

--- a/packages/agent-sdk/src/openai/index.ts
+++ b/packages/agent-sdk/src/openai/index.ts
@@ -1,0 +1,3 @@
+export * from "./params";
+export * from "./response";
+export * from "./schema";

--- a/packages/agent-sdk/src/openai/params.ts
+++ b/packages/agent-sdk/src/openai/params.ts
@@ -1,0 +1,35 @@
+export const chainIdParam = {
+  name: "chainId",
+  in: "query",
+  required: true,
+  description: "EVM Network (aka chain ID)",
+  schema: { type: "number" },
+  example: 100,
+};
+
+export const addressParam = {
+  name: "address",
+  in: "query",
+  required: true,
+  description: "20 byte Ethereum address with 0x prefix",
+  schema: { type: "string" },
+};
+
+export const addressOrSymbolParam = {
+  name: "address",
+  in: "query",
+  required: true,
+  description:
+    "The ERC-20 token symbol or address to be sold, if provided with the symbol do not try to infer the address.",
+  schema: { type: "string" },
+  example: "0x6810e776880c02933d47db1b9fc05908e5386b96",
+};
+
+export const amountParam = {
+  name: "amount",
+  in: "query",
+  required: true,
+  description: "Amount in human-readable units (not wei)",
+  schema: { type: "number" },
+  example: 0.123,
+};

--- a/packages/agent-sdk/src/openai/response.ts
+++ b/packages/agent-sdk/src/openai/response.ts
@@ -1,0 +1,19 @@
+export const SignRequestResponse200 = {
+  description: "Successful signing request",
+  content: {
+    "application/json": {
+      schema: {
+        type: "object",
+        required: ["transaction"],
+        properties: {
+          transaction: { $ref: "#/components/schemas/SignRequest" },
+          meta: {
+            type: "object",
+            additionalProperties: true,
+            example: { message: "Submitted" },
+          },
+        },
+      },
+    },
+  },
+};

--- a/packages/agent-sdk/src/openai/schema.ts
+++ b/packages/agent-sdk/src/openai/schema.ts
@@ -1,0 +1,58 @@
+export const AddressSchema = {
+  description: "20 byte Ethereum address encoded as a hex with `0x` prefix.",
+  type: "string",
+  example: "0x6810e776880c02933d47db1b9fc05908e5386b96",
+};
+
+export const MetaTransactionSchema = {
+  type: "object",
+  description: "Sufficient data representing an EVM transaction",
+  properties: {
+    to: { $ref: "#/components/schemas/Address" },
+    data: {
+      type: "string",
+      description: "Transaction calldata",
+      example: "0xd0e30db0",
+    },
+    value: {
+      type: "string",
+      description: "Transaction value",
+      example: "0x1b4fbd92b5f8000",
+    },
+  },
+  required: ["to", "data", "value"],
+};
+
+export const SignRequestSchema = {
+  type: "object",
+  required: ["method", "chainId", "params"],
+  properties: {
+    method: {
+      type: "string",
+      enum: [
+        "eth_sign",
+        "personal_sign",
+        "eth_sendTransaction",
+        "eth_signTypedData",
+        "eth_signTypedData_v4",
+      ],
+      description: "The signing method to be used.",
+    },
+    chainId: {
+      type: "integer",
+      description: "The ID of the Ethereum chain.",
+    },
+    params: {
+      oneOf: [
+        {
+          type: "array",
+          items: { $ref: "#/components/schemas/MetaTransaction" },
+        },
+        {
+          type: "array",
+          items: { type: "string" },
+        },
+      ],
+    },
+  },
+};


### PR DESCRIPTION
This should make writing agent manifests a bit easier.

cf.

https://near-cow-agent.vercel.app/.well-known/ai-plugin.json
https://near-uniswap-agent.vercel.app/.well-known/ai-plugin.json
https://near-safe-agent.vercel.app/.well-known/ai-plugin.json
https://lifi-agent.vercel.app/.well-known/ai-plugin.json

Specifically, how LiFi Agent already partially does this:

https://github.com/bh2smith/lifi-agent/blob/main/src/app/api/ai-plugin/route.ts